### PR TITLE
Drop unused and deprecated import

### DIFF
--- a/fas/views.py
+++ b/fas/views.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.contrib import messages
 from django.contrib.auth import login as auth_login, logout as auth_logout, authenticate, REDIRECT_FIELD_NAME
-from django.core.urlresolvers import resolve
 from django.http import HttpResponseRedirect
 from django.shortcuts import resolve_url, redirect
 from django.utils.translation import ugettext_lazy as _


### PR DESCRIPTION
Importing from `django.core.urlresolvers` is deprecated, and the module itself is removed in Django 2.0. Since the imported `resolve` function is not used in the module, it should be safe to just drop the import line.