### PR TITLE
Accept request parameter in FasBackend.authenticate

### DIFF
--- a/fas/backend.py
+++ b/fas/backend.py
@@ -7,8 +7,8 @@ from openid.extensions import sreg
 from .consumer import SUCCESS
 
 class FasBackend(ModelBackend):
-    def authenticate(self, response):
-        if response.status != SUCCESS:
+    def authenticate(self, request=None, *, response=None):
+        if response is None or response.status != SUCCESS:
             raise PermissionDenied()
         User = get_user_model()
         response = sreg.SRegResponse.fromSuccessResponse(response)


### PR DESCRIPTION
According to [1.11 release notes][1] and [2.1 deprecation notes][2], the `ModelBackend.authenticate` method should/must accept HTTP request object (which may be `None`) as the first positional argument. Failure to do so results in the backend being always skipped in Django 2.1+.

[1]: https://docs.djangoproject.com/en/2.1/releases/1.11/#id2
[2]: https://docs.djangoproject.com/en/2.1/internals/deprecation/#deprecation-removed-in-2-1